### PR TITLE
Order added

### DIFF
--- a/models/floorplan.py
+++ b/models/floorplan.py
@@ -5,7 +5,7 @@ class FloorPlan(Base):
     __tablename__ = "floor_plans"
 
     id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, nullable=False)
+    name = Column(String, nullable=False, unique=True)
     details = Column(Text, nullable=True)
     image = Column(String, nullable=True)
-    order = Column(Integer, nullable=False, default=0) 
+    order = Column(Integer, nullable=False, default=0, unique=True) 

--- a/models/floorplan.py
+++ b/models/floorplan.py
@@ -8,3 +8,4 @@ class FloorPlan(Base):
     name = Column(String, nullable=False)
     details = Column(Text, nullable=True)
     image = Column(String, nullable=True)
+    order = Column(Integer, nullable=False, default=0) 

--- a/router/floorplan.py
+++ b/router/floorplan.py
@@ -5,6 +5,7 @@ from dependencies.database import get_db
 from dependencies.auth import check_role
 from ..schemas.floorplan import FloorPlanCreate, FloorPlan as FloorPlanSchema
 from ..services.floorplan_service import FloorPlanService
+from typing import List
 
 router = Router()
 
@@ -40,3 +41,15 @@ def delete_floorplan(
     user=Depends(check_role(["cb-manage_floorplans"]))
 ):
     return FloorPlanService(db).delete(floorplan_id)
+
+@router.patch("/order")
+def update_orders(
+    orders: List[dict],
+    db: Session = Depends(get_db),
+    user=Depends(check_role(["cb-manage_floorplans"]))
+):
+    for order in orders:
+        fp = FloorPlanService(db).get(order["id"])
+        fp.order = order["order"]
+    db.commit()
+    return {"status": "ok"}

--- a/schemas/floorplan.py
+++ b/schemas/floorplan.py
@@ -5,6 +5,7 @@ class FloorPlanBase(BaseModel):
     name: str
     details: Optional[str] = None
     image: Optional[str] = None
+    order: Optional[int] = None  # NOVO
 
 class FloorPlanCreate(FloorPlanBase):
     pass

--- a/services/floorplan_service.py
+++ b/services/floorplan_service.py
@@ -13,7 +13,7 @@ class FloorPlanService:
         self.db = db
 
     def list(self) -> List[FloorPlanModel]:
-        return self.db.query(FloorPlanModel).all()
+        return self.db.query(FloorPlanModel).order_by(FloorPlanModel.order).all()
 
     def get(self, floorplan_id: int) -> FloorPlanModel:
         fp = self.db.query(FloorPlanModel).filter_by(id=floorplan_id).first()
@@ -34,7 +34,14 @@ class FloorPlanService:
             )
             image = media.uuid
 
-        new_fp = FloorPlanModel(**data.dict(exclude={"image"}), image=image)
+        max_order = self.db.query(FloorPlanModel).order_by(FloorPlanModel.order.desc()).first()
+        new_order = (max_order.order + 1) if max_order else 1
+
+        new_fp = FloorPlanModel(
+            **data.dict(exclude={"image", "order"}),
+            image=image,
+            order=new_order
+        )
         self.db.add(new_fp)
         self.db.commit()
         self.db.refresh(new_fp)

--- a/services/floorplan_service.py
+++ b/services/floorplan_service.py
@@ -22,6 +22,9 @@ class FloorPlanService:
         return fp
 
     def create(self, data: FloorPlanCreate) -> FloorPlanModel:
+        if self.db.query(FloorPlanModel).filter_by(name=data.name).first():
+            raise HTTPException(status_code=400, detail="Floor plan with this name already exists")
+
         image = data.image
         if not image or not is_valid_url(image):
             alias = f"{slugify(data.name)}-{uuid4()}"
@@ -48,6 +51,15 @@ class FloorPlanService:
         return new_fp
 
     def update(self, floorplan_id: int, data: FloorPlanCreate) -> FloorPlanModel:
+        if self.db.query(FloorPlanModel).filter_by(name=data.name).first():
+            existing_fp = self.db.query(FloorPlanModel).filter_by(name=data.name).first()
+            if existing_fp.id != floorplan_id:
+                raise HTTPException(status_code=400, detail="Floor plan with this name already exists")
+        if data.order:
+            existing_order_fp = self.db.query(FloorPlanModel).filter_by(order=data.order).first()
+            if existing_order_fp and existing_order_fp.id != floorplan_id:
+                raise HTTPException(status_code=400, detail="Floor plan with this order already exists")
+
         fp = self.get(floorplan_id)
         update_data = data.dict(exclude_unset=True)
 


### PR DESCRIPTION
This pull request introduces changes to the `FloorPlan` model, schema, router, and service to support unique ordering of floor plans and ensure name uniqueness. It also adds functionality to update the order of multiple floor plans and enforces constraints during creation and updates.

### Database Model Enhancements:
* Updated the `FloorPlan` model to include a unique `order` field with a default value of 0, and enforced uniqueness for the `name` field to prevent duplicate entries. (`models/floorplan.py`)

### Router Enhancements:
* Added a new `update_orders` endpoint to allow batch updates of floor plan orders. (`router/floorplan.py`)

### Schema Changes:
* Extended the `FloorPlanBase` schema to include an optional `order` field for better alignment with the model. (`schemas/floorplan.py`)

### Service Improvements:
* Modified the `list` method to return floor plans ordered by the `order` field. (`services/floorplan_service.py`)
* Enhanced the `create` and `update` methods to enforce uniqueness for `name` and `order` fields, and automatically assign the next available order during creation. (`services/floorplan_service.py`) [[1]](diffhunk://#diff-f9bfafde592972d4b1a58651d8319fd5c47cad3cf97a4ebac208e62de2893a38R25-R27) [[2]](diffhunk://#diff-f9bfafde592972d4b1a58651d8319fd5c47cad3cf97a4ebac208e62de2893a38L37-R62)