### PR TITLE
selector added

### DIFF
--- a/schemas/floorplan_component.py
+++ b/schemas/floorplan_component.py
@@ -1,11 +1,12 @@
+from pydantic import Field
 from schemas.ui.page import BaseComponentSchema
 from schemas.ui.components.title import Title
 from schemas.ui.components.text import Text
 from schemas.ui.components.image import Image
-from pydantic import Field
 
 
 class FloorPlanComponent(BaseComponentSchema):
     title: Title = Field(..., description="Title of the floor plan section")
     description: Text = Field(..., description="Descriptive text for the floor plan")
     image: Image = Field(..., description="Floor plan image component")
+    show_selector: bool = Field(default=True, description="Whether to show the floor plan selector")


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `FloorPlanComponent` schema by adding a new field and reorganizing imports.

Schema enhancement:

* [`schemas/floorplan_component.py`](diffhunk://#diff-44a9b49c1a4b96ebf4196225cd51ee27ca25fd22db6ac0d744c006afb226e814R1-R12): Added a new `show_selector` field to the `FloorPlanComponent` schema, which is a boolean indicating whether to display the floor plan selector. This field defaults to `True`.

Code cleanup:

* [`schemas/floorplan_component.py`](diffhunk://#diff-44a9b49c1a4b96ebf4196225cd51ee27ca25fd22db6ac0d744c006afb226e814R1-R12): Reorganized imports by moving the `Field` import to the top of the file.